### PR TITLE
fixed Pillow imports and ffmpeg

### DIFF
--- a/experiments/detector.py
+++ b/experiments/detector.py
@@ -4,7 +4,7 @@ from vision import *
 from vision.visualize import highlight_box
 from vision import features
 from vision.toymaker import *
-import Image
+from PIL import Image
 import numpy
 import pylab
 from scipy.io import savemat as savematlab

--- a/experiments/features.py
+++ b/experiments/features.py
@@ -1,5 +1,5 @@
 from vision import features
-import Image
+from PIL import Image
 from scipy.io import savemat as savematlab
 
 im = Image.open("/scratch/vatic/syn-bounce-level/0/0/0.jpg")

--- a/experiments/toymarginals.py
+++ b/experiments/toymarginals.py
@@ -6,7 +6,7 @@ import os
 import multiprocessing
 import logging
 import random
-import ImageColor
+from PIL import ImageColor
 import pylab
 import pickle
 

--- a/vision/drawer.py
+++ b/vision/drawer.py
@@ -13,8 +13,8 @@ The only dependencies are Tkinter and PIL (it does not depend on pyvision).
 """
 
 from Tkinter import *
-import Image
-import ImageTk
+from PIL import Image
+from PIL import ImageTk
 
 try:
     import vision

--- a/vision/ffmpeg.py
+++ b/vision/ffmpeg.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import random
-import Image
+from PIL import Image
 
 class extract(object):
     def __init__(self, path, fps = None, size = None):

--- a/vision/ffmpeg.py
+++ b/vision/ffmpeg.py
@@ -3,6 +3,26 @@ import shutil
 import random
 from PIL import Image
 
+def which(program):
+    """Function to check for presence of executable/installed program
+       Used for checking presense of ffmpeg/avconv"""
+    import os
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
 class extract(object):
     def __init__(self, path, fps = None, size = None):
         self.key = int(random.random() * 1000000000)
@@ -14,7 +34,10 @@ class extract(object):
         except:
             pass
 
-        cmd = "ffmpeg -i {0} -b 10000k".format(path)
+        if which("ffmpeg") is not None:
+            cmd = "ffmpeg -i {0} -b 10000k".format(path)
+        else:
+            cmd = "avconv -i {0} -b 10000k".format(path)
         if fps:
             cmd = "{0} -r {1}".format(cmd, int(fps))
         if size:

--- a/vision/frameiterators.py
+++ b/vision/frameiterators.py
@@ -1,4 +1,4 @@
-import Image
+from PIL import Image
 import os
 
 class frameiterator(object):

--- a/vision/pascal.py
+++ b/vision/pascal.py
@@ -11,7 +11,7 @@ Example usage:
 
 from vision import Box
 import os
-import Image
+from PIL import Image
 import logging
 from xml.etree import ElementTree
 

--- a/vision/visualize.py
+++ b/vision/visualize.py
@@ -1,4 +1,4 @@
-import ImageDraw
+from PIL import ImageDraw
 import itertools
 import random
 import logging


### PR DESCRIPTION
Using `import Image` does not work with the latest versions of Pillow. In this version I have changed all PIL related imports to use the proper import format `from PIL import <class>`

Also added code to check whether the system has `ffmpeg` installed or the newer replacement `avconv`. Usage should be the same.
