### PR TITLE
`enum solver_type`  inplace of unnamed enum type

### DIFF
--- a/vision/liblinear/linear.h
+++ b/vision/liblinear/linear.h
@@ -19,7 +19,7 @@ struct problem
 	double bias;            /* < 0 if no bias term */  
 };
 
-enum { L2R_LR, L2R_L2LOSS_SVC_DUAL, L2R_L2LOSS_SVC, L2R_L1LOSS_SVC_DUAL, MCSVM_CS, L1R_L2LOSS_SVC, L1R_LR }; /* solver_type */
+enum solver_type { L2R_LR, L2R_L2LOSS_SVC_DUAL, L2R_L2LOSS_SVC, L2R_L1LOSS_SVC_DUAL, MCSVM_CS, L1R_L2LOSS_SVC, L1R_LR }; /* solver_type */
 
 struct parameter
 {


### PR DESCRIPTION
when I was running cython on svm.pyx it was giving this error
`vision/svm.cpp:1379:72: error: use of enum ‘solver_type’ without previous declaration
 tic CYTHON_INLINE PyObject* __Pyx_PyInt_From_enum__solver_type(enum solver_type
                                                                     ^
`
Adding `enum solver_type` fixed it.